### PR TITLE
Optimize surge fuzzing

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -127,9 +127,11 @@ func FuzzSurgeAttack(f *testing.F) {
 		0x55, 0xF6, 0x48, 0x12, 0x00, 0x00, 0x00, 0x00, // 306875861
 		0x8C, 0xDA, 0x2C, 0x10, 0x00, 0x00, 0x00, 0x00, // 271043852
 	}
-	f.Add(uint32(10), honestPeers)
+	f.Add(honestPeers)
 
-	f.Fuzz(func(t *testing.T, peerCount uint32, peerTraffic []byte) {
+	f.Fuzz(func(t *testing.T, peerTraffic []byte) {
+		peerCount := len(peerTraffic) / 8
+
 		// Attacks are only interesting with 2+ nodes.
 		if peerCount < 2 || peerCount > 1000 {
 			return
@@ -139,11 +141,6 @@ func FuzzSurgeAttack(f *testing.F) {
 
 		// Cutoff must be a valid index in the peer count slice.
 		if cutoff >= int(peerCount) {
-			return
-		}
-
-		// We need traffic flows expressed as uint64 for each node.
-		if len(peerTraffic) < int(peerCount)*8 {
 			return
 		}
 

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"math/rand"
 	"testing"
 )
 
@@ -127,9 +126,9 @@ func FuzzSurgeAttack(f *testing.F) {
 		0x55, 0xF6, 0x48, 0x12, 0x00, 0x00, 0x00, 0x00, // 306875861
 		0x8C, 0xDA, 0x2C, 0x10, 0x00, 0x00, 0x00, 0x00, // 271043852
 	}
-	f.Add(honestPeers)
+	f.Add(uint16(5), honestPeers)
 
-	f.Fuzz(func(t *testing.T, peerTraffic []byte) {
+	f.Fuzz(func(t *testing.T, cutoffParam uint16, peerTraffic []byte) {
 		peerCount := len(peerTraffic) / 8
 
 		// Attacks are only interesting with 2+ nodes.
@@ -137,12 +136,7 @@ func FuzzSurgeAttack(f *testing.F) {
 			return
 		}
 
-		cutoff := int(rand.Intn(int(peerCount)))
-
-		// Cutoff must be a valid index in the peer count slice.
-		if cutoff >= int(peerCount) {
-			return
-		}
+		cutoff := int(cutoffParam) % peerCount
 
 		honestPeers := make([]uint64, peerCount)
 		for i := 0; i < int(peerCount); i++ {


### PR DESCRIPTION
After these changes, the fuzz test quickly finds valid surge attacks:

```shell
$ go test -run=FuzzSurgeAttack/e8e56d18133e
27e4                                                                        
--- FAIL: FuzzSurgeAttack (0.00s)                                           
    --- FAIL: FuzzSurgeAttack/e8e56d18133e27e4 (0.00s)                      
        fuzz_test.go:171: Successful attack: Peer count: 18, cutoff: 17:    
              - 808464432 reputation (6m) contributes 67372036 revenue (2w) 
              - 808464432 reputation (6m) contributes 67372036 revenue (2w) 
              - 808464432 reputation (6m) contributes 67372036 revenue (2w) 
              - 808464432 reputation (6m) contributes 67372036 revenue (2w) 
              - 808464432 reputation (6m) contributes 67372036 revenue (2w) 
              - 808464432 reputation (6m) contributes 67372036 revenue (2w) 
              - 808464432 reputation (6m) contributes 67372036 revenue (2w) 
              - 808464432 reputation (6m) contributes 67372036 revenue (2w) 
              - 48053104688 reputation (6m) contributes 4004425390 revenue (2w)                                                                         
              - 52348071984 reputation (6m) contributes 4362339332 revenue (2w)                                                                         
              - 52348071984 reputation (6m) contributes 4362339332 revenue (2w)                                                                         
              - 69527941168 reputation (6m) contributes 5793995097 revenue (2w)                                                                         
              - 69527941168 reputation (6m) contributes 5793995097 revenue (2w)                                                                         
              - 69527941168 reputation (6m) contributes 5793995097 revenue (2w)                                                                         
              - 69527941168 reputation (6m) contributes 5793995097 revenue (2w)                                                                         
              - 86707810352 reputation (6m) contributes 7225650862 revenue (2w)                                                                         
              - 86707810352 reputation (6m) contributes 7225650862 revenue (2w)                                                                         
              - 86707810352 reputation (6m) contributes 7225650862 revenue (2w)                                                                         
             with outcome: Node lost: 50 % of revenue  - attacker paid: 28586797036 to meet threshold: 58121013316, node still earned: 28586797036 (0 honest + 28586797036 attacker), <nil>                                         
FAIL                                                                        

```